### PR TITLE
第8回授業

### DIFF
--- a/07/dockercompose.yaml
+++ b/07/dockercompose.yaml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  wordpress:
+    image: wordpress:latest
+    container_name: whitehouse_wordpress
+    ports:
+      - "8000:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+    volumes:
+      - wordpress_data:/var/www/html
+    depends_on:
+      - db
+
+  db:
+    image: mariadb:latest
+    container_name: whitehouse_db
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_ROOT_PASSWORD: annpannman
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  wordpress_data:
+  db_data:

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.381.1 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: kubernetes-sigs/kind@v0.29.0
+- name: kubernetes/kubernetes/kubectl@v1.33.2
+- name: derailed/k9s@v0.50.6
+- name: helm/helm@v3.18.3

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -15,3 +15,4 @@ packages:
 - name: kubernetes/kubernetes/kubectl@v1.33.2
 - name: derailed/k9s@v0.50.6
 - name: helm/helm@v3.18.3
+- name: kubernetes-sigs/kustomize@kustomize/v5.7.0

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/k8s/db-deployment.yaml
+++ b/k8s/db-deployment.yaml
@@ -30,6 +30,13 @@ spec:
                 secretKeyRef:
                   name: wp-secret
                   key: MYSQL_ROOT_PASSWORD
+          resources:
+            requests:
+              cpu: "55m"
+              memory: "220Mi"
+            limits:
+              cpu: "165m"
+              memory: "660Mi"
           volumeMounts:
             - name: db-volume
               mountPath: /var/lib/mysql

--- a/k8s/db-deployment.yaml
+++ b/k8s/db-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb:latest
+          env:
+            - name: MYSQL_DATABASE
+              value: wordpress
+            - name: MYSQL_USER
+              value: wordpress
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wp-secret
+                  key: MYSQL_PASSWORD
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wp-secret
+                  key: MYSQL_ROOT_PASSWORD
+          volumeMounts:
+            - name: db-volume
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: db-volume
+          persistentVolumeClaim:
+            claimName: db-pvc

--- a/k8s/db-pvc.yaml
+++ b/k8s/db-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/db-service.yaml
+++ b/k8s/db-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+spec:
+  selector:
+    app: mariadb
+  ports:
+    - port: 3306

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - db-pvc.yaml
+  - wordpress-pvc.yaml
+  - db-deployment.yaml
+  - db-service.yaml
+  - wordpress-deployment.yaml
+  - wordpress-service.yaml

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wp-secret
+type: Opaque
+stringData:
+  WORDPRESS_DB_PASSWORD: wordpress
+  MYSQL_PASSWORD: wordpress
+  MYSQL_ROOT_PASSWORD: annpannman

--- a/k8s/wordpress-deployment.yaml
+++ b/k8s/wordpress-deployment.yaml
@@ -29,6 +29,13 @@ spec:
                 secretKeyRef:
                   name: wp-secret
                   key: WORDPRESS_DB_PASSWORD
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "130Mi"
+            limits:
+              cpu: "150m"
+              memory: "390Mi"
           volumeMounts:
             - name: wp-volume
               mountPath: /var/www/html

--- a/k8s/wordpress-deployment.yaml
+++ b/k8s/wordpress-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+        - name: wordpress
+          image: wordpress:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: WORDPRESS_DB_HOST
+              value: mariadb
+            - name: WORDPRESS_DB_NAME
+              value: wordpress
+            - name: WORDPRESS_DB_USER
+              value: wordpress
+            - name: WORDPRESS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wp-secret
+                  key: WORDPRESS_DB_PASSWORD
+          volumeMounts:
+            - name: wp-volume
+              mountPath: /var/www/html
+      volumes:
+        - name: wp-volume
+          persistentVolumeClaim:
+            claimName: wordpress-pvc

--- a/k8s/wordpress-pvc.yaml
+++ b/k8s/wordpress-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wordpress-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/wordpress-service.yaml
+++ b/k8s/wordpress-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+spec:
+  type: NodePort
+  selector:
+    app: wordpress
+  ports:
+    - port: 80
+      targetPort: 80
+      nodePort: 30080


### PR DESCRIPTION
## なぜやるか

- リソース設定の見直しは、パフォーマンスの最適化、コスト削減、クラスタ全体の安定運用に不可欠だから

## なにをやったのか

- kustomizeのインストール
- kustomize build . |kubectl apply -f -で manifest の内容でデプロイされる
- kind で pod のリソースが確認できるようにするために metrics-server をデプロイ
　- kubectl apply -f https://raw.githubusercontent.com/kdg-server-2025/server-honahuku/refs/heads/main/metrics-server.yaml
- wordpress にアクセスできるように port-fowward する
　- kubectl port-forward service/wordpress 8080:8080 > /dev/null
- 新しい vscode の terminal のタブで curl を使って負荷を掛ける。
　- while true; do curl http://localhost:8080/ > /dev/null; sleep 0.1; done 
- kubectl top podsで負荷を確認

## 写真
<img width="1157" height="338" alt="スクリーンショット 2025-07-23 18 29 25" src="https://github.com/user-attachments/assets/90f40eab-92c1-4f09-a93d-9a136fda1b86" />

